### PR TITLE
Track connection status manually - more reliable

### DIFF
--- a/CaveBLE.kt
+++ b/CaveBLE.kt
@@ -49,24 +49,28 @@ class CaveBLE(val device: BluetoothDevice,
     private var command: BluetoothGattCharacteristic? = null
     private var dataIn: BluetoothGattCharacteristic? = null
     private var bluetoothGatt: BluetoothGatt? = null
+    private var _isConnected = false
     private val callback = object: BluetoothGattCallback() {
         override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
             val deviceAddress = gatt.device.address
 
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    _isConnected = true
                     bluetoothGatt = gatt
                     Handler(Looper.getMainLooper()).post {
                         bluetoothGatt?.discoverServices()
                     }
                 } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                     Log.w("BluetoothGattCallback", "Successfully disconnected from $deviceAddress")
+                    _isConnected = false
                     gatt.close()
                     statusCallback?.invoke(DISCONNECTED, "Successful disconnection")
                 }
             } else {
                 val msg = "Error $status encountered for $deviceAddress! Disconnecting..."
                 Log.w("BluetoothGattCallback", msg)
+                _isConnected = false
                 gatt.close()
                 statusCallback?.invoke(CONNECTION_FAILED, msg)
             }
@@ -123,9 +127,7 @@ class CaveBLE(val device: BluetoothDevice,
     }
 
     fun isConnected(): Boolean {
-        val bluetoothMgr: BluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val devs = bluetoothMgr.getConnectedDevices(BluetoothProfile.GATT)
-        return (device in devs)
+        return _isConnected
     }
 
     fun sendCommand(value: Int) {


### PR DESCRIPTION
Changed to track status of the connection manually. Use the callback to store a variable whether we are currently connected. The existing method (calling BluetoothManager.getConnectedDevices() - queries the Android stack which may not be updated until sometime later).